### PR TITLE
fix failure when cythoning kivy/core/window_11

### DIFF
--- a/pythonforandroid/recipes/kivy/__init__.py
+++ b/pythonforandroid/recipes/kivy/__init__.py
@@ -1,6 +1,6 @@
 
 from pythonforandroid.toolchain import CythonRecipe, shprint, current_directory, ArchARM
-from os.path import exists, join
+from os.path import exists, join, basename
 import sh
 import glob
 
@@ -29,6 +29,14 @@ class KivyRecipe(CythonRecipe):
             for dirn in build_libs_dirs:
                 shprint(sh.cp, '-r', join('kivy', 'include'),
                         join(dirn, 'kivy'))
+
+    def cythonize_file(self, env, build_dir, filename):
+        # We can ignore a few files that aren't important to the
+        # android build, and may not work on Android anyway
+        do_not_cythonize = ['window_x11.pyx', ]
+        if basename(filename) in do_not_cythonize:
+            return
+        super(KivyRecipe, self).cythonize_file(env, build_dir, filename)
 
     def get_recipe_env(self, arch):
         env = super(KivyRecipe, self).get_recipe_env(arch)


### PR DESCRIPTION
when compile recipes, it always failed with window_11.It has been fixed in kivy/master branch,but that one doesn't work for me. So I copied the recipe file of kivy in master branch to fix this.